### PR TITLE
feat: Add automatic job document cleanup with 5-day TTL

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A fault-tolerant distributed worker-consumer system built using **Node.js**, **M
 
 ## 🚀 Recent Major Updates
 
-- **Jobs Tracking System:** Complete lifecycle tracking for all queue processing operations with status monitoring and performance metrics
+- **Jobs Tracking System:** Complete lifecycle tracking with automatic cleanup - job documents auto-purge after 5 days
 - **Dynamic Concurrency Control:** Consumers now fetch queue-specific concurrency from database instead of using fixed environment variables
 - **Enhanced Assignment Collection:** Assignment documents include queue ObjectId references for proper data relationships
 - **AWS SDK v3:** Upgraded to modern, modular AWS SDK for better performance and maintenance
@@ -99,6 +99,7 @@ Comprehensive tracking for all queue processing operations with real-time status
 - **Performance Metrics:** Message counts, processing duration, timing analytics
 - **Process Attribution:** Full traceability of which worker/consumer handled each job
 - **Efficient Indexing:** Compound indexes on `{status, createdAt}` and `{queueUrl, status}` for fast queries
+- **Automatic Cleanup:** TTL index automatically purges job documents after 5 days from last modification
 
 ## 💡 Use Cases
 

--- a/server.js
+++ b/server.js
@@ -78,6 +78,13 @@ async function ensureIndexes() {
       { background: true }
     )
     console.log('Ensured compound index on jobs.queueUrl and jobs.status')
+
+    // Create TTL index for automatic job document cleanup (5 days = 432000 seconds)
+    await db.collection('jobs').createIndex(
+      { lastModified: 1 },
+      { expireAfterSeconds: 432000, background: true }
+    )
+    console.log('Ensured TTL index on jobs.lastModified (5 days auto-purge)')
     
     await client.close()
   } catch (err) {


### PR DESCRIPTION
Enhancement Details:
- Added MongoDB TTL index on jobs.lastModified field
- Automatic purging of job documents after 5 days (432000 seconds)
- Background processing ensures no performance impact
- Updated README.md to document automatic cleanup feature

Technical Implementation:
- TTL index created in server.js ensureIndexes function
- Index runs in background mode for non-blocking operation
- MongoDB automatically handles document deletion based on lastModified timestamp
- No application code changes needed - fully automatic cleanup

Benefits:
- Prevents unlimited growth of jobs collection
- Maintains 5-day audit trail for debugging and monitoring
- Zero maintenance overhead - MongoDB handles all cleanup
- Configurable TTL duration if needed in future

Verified:
- TTL index created successfully with 432000 second expiration
- Index running in background mode
- lastModified field properly indexed for efficient cleanup